### PR TITLE
Add CommonJS support

### DIFF
--- a/src/leonardo/module.js
+++ b/src/leonardo/module.js
@@ -74,3 +74,8 @@ angular.module('leonardo', ['leonardo.templates', 'ngMockE2E'])
   .run(['leoConfiguration', function(leoConfiguration) {
       leoConfiguration.loadSavedStates();
     }]);
+
+// Common.js package manager support (e.g. ComponentJS, WebPack)
+if (typeof module !== "undefined" && typeof exports !== "undefined" && module.exports === exports) {
+  module.exports = 'leonardo';
+}


### PR DESCRIPTION
Can we add support for loading the module as a CommonJS module?

See example of Angular UI-Router:
https://github.com/angular-ui/ui-router/blob/master/release/angular-ui-router.js

This will allow doing:
```js
var leonardo = require('leonardo');

angular.module('app', [
    leonardo
])
```

Instead of hard coding the module name.