### PR TITLE
Requiring Leonardo loads the Flicker example file instead of the library

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "leonardojs",
   "version": "1.0.8",
   "description": "Leonardo ========",
-  "main": "index.js",
+  "main": "dist/leonardo.js",
   "scripts": {
     "test": "test",
     "docs:example": "./node_modules/docco/bin/docco index.js --template=./build/docs/resources/example/docco.jst --output=./",


### PR DESCRIPTION
`main` should point to the library file to allow doing:

```
var leonardo = require('leonardojs');
```

Instead of:

```
var leonardo = require('leonardojs/dist/leonardo');
```