### PR TITLE
decode url for url match to work properly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4549,7 +4549,7 @@
     },
     "next-tick": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
@@ -5568,7 +5568,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -6390,7 +6390,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -7087,7 +7087,7 @@
     },
     "webpack-dev-middleware": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-2.0.6.tgz",
+      "resolved": "http://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-2.0.6.tgz",
       "integrity": "sha512-tj5LLD9r4tDuRIDa5Mu9lnY2qBBehAITv6A9irqXhw/HQquZgTx3BCd57zYbU2gMDnncA49ufK2qVQSbaKJwOw==",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leonardojs",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "description": "Leonardo - Your mocking ninja - an add-on tool for centralizing your client side mocking",
   "main": "dist/leonardo.js",
   "scripts": {

--- a/src/leonardo/xhr-mock.srv.ts
+++ b/src/leonardo/xhr-mock.srv.ts
@@ -11,7 +11,15 @@ export class XhrMock {
   private init() {
     xhrMock.setup();
     xhrMock.use(async (request: MockRequest, response: MockResponse) => {
-      const state = Leonardo.fetchStatesByUrlAndMethod(request.url().toString(), request.method());
+      let url = request.url().toString();
+      const {fetchStatesByUrlAndMethod} = Leonardo;
+
+      let state = fetchStatesByUrlAndMethod(url, request.method());
+
+      if (!state && decodeURIComponent(url) !== url) {
+        state = fetchStatesByUrlAndMethod(decodeURIComponent(url), request.method())
+      }
+
       if (state && state.active) {
         const activeOption = Leonardo.getActiveStateOption(state.name);
         if (!!activeOption) {

--- a/src/leonardo/xhr-mock.srv.ts
+++ b/src/leonardo/xhr-mock.srv.ts
@@ -11,9 +11,8 @@ export class XhrMock {
   private init() {
     xhrMock.setup();
     xhrMock.use(async (request: MockRequest, response: MockResponse) => {
-      let url = request.url().toString();
-      const {fetchStatesByUrlAndMethod} = Leonardo;
-
+      const url = request.url().toString();
+      const { fetchStatesByUrlAndMethod } = Leonardo;
       let state = fetchStatesByUrlAndMethod(url, request.method());
 
       if (!state && decodeURIComponent(url) !== url) {


### PR DESCRIPTION
https://github.com/jameslnewell/xhr-mock/issues/63
since the url is encoded when calling request.url().toString() it is failing to compare some url that have commas and such  this will help to solve
until the above issue is fixed