### PR TITLE
ci: updated node versions in strategy matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['9.x', 'latest']
+        node-version: ['10.x', '14.x', '16.0']
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
@@ -29,7 +29,7 @@ jobs:
             ${{ runner.os }}-npm-
 
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
           

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['10.x', '14.x', '16.0']
+        node-version: ['10.x', '12.x', '14.0']
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
@@ -35,6 +35,8 @@ jobs:
           
       - name: Install Dependencies
         run: npm ci
-
+      
       - name: Run tests
-        run: npm run test
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: npm test


### PR DESCRIPTION
# WHATS NEW
* Replaced `node-versions` to `10.x`, `14.x`, and `16.x`